### PR TITLE
Only honor GPS overrides INSIDE the perimeter.

### DIFF
--- a/code/Raindancer/perimeter.cpp
+++ b/code/Raindancer/perimeter.cpp
@@ -118,7 +118,7 @@ void TPerimeterThread::CaluculateInsideOutsideL(int32_t magl) {
 	// Overwrite values when inside GPS polygon
 	if (CONF_USE_GPS_POLYGON) // Check if the gps signal shows, that robot is inside the defined gps polygon.
 	{
-		if (srvGps.flagInsidePolygon && abs(magnetudeL) < CONF_PER_THRESHOLD_IGNORE_GPS) // only check if amplitude is lower than threshold
+		if (srvGps.flagInsidePolygon && 0 < magnetudeL && magnetudeL < CONF_PER_THRESHOLD_IGNORE_GPS) // only check if amplitude is lower than threshold
 		{
 			signalCounterLFast = 2;
 			signalCounterL = 3;
@@ -176,7 +176,7 @@ void TPerimeterThread::CaluculateInsideOutsideR(int32_t magr) {
 	// Overwrite values when inside GPS polygon
 	if (CONF_USE_GPS_POLYGON) // Check if the srvGps signal shows, that robot is inside the defined gps polygon.
 	{
-		if (srvGps.flagInsidePolygon && abs(magnetudeR) < CONF_PER_THRESHOLD_IGNORE_GPS) // only check if amplitude is lower than threshold
+		if (srvGps.flagInsidePolygon && 0 < magnetudeR && magnetudeR < CONF_PER_THRESHOLD_IGNORE_GPS) // only check if amplitude is lower than threshold
 		{
 			signalCounterRFast = 2;
 			signalCounterR = 3;


### PR DESCRIPTION
On a large lawn, furthest from the perimeter-sender,
after crossing the perimiter wire, the magnitude might
quickly drop-off, preventing us from honoring
the 'outside-ness' of the signal.

This prevents the GPS flagInsidePolygon from being
activated if the current perimeter-sensor magnitude
indicates that we were/are outside the perimeter.

This is especially useful because GPS coordinates can be
up 6+ meters inaccurate, making a GPS bounding box intersect
with boundary wire sections.