### PR TITLE
Alternate the mower disc direction.

### DIFF
--- a/code/Raindancer/MC33926.cpp
+++ b/code/Raindancer/MC33926.cpp
@@ -95,6 +95,7 @@ void MC33926Wheels::resetFault(bool force) {
 
 MC33926Mow::MC33926Mow() {
 	m_power = 999;
+  disc_direction_positive = true;
 }
 
 MC33926Mow::~MC33926Mow() {
@@ -107,6 +108,17 @@ void MC33926Mow::motor(byte motor, int power) {
 	power = power > 255 ? 255 : power;
 	power = power < -255 ? -255 : power;
 
+  if (!CONF_DISABLE_MOW_MOTOR_ALTERNATE_DIRECTION) {
+    if (power == 0) {
+      // Alternate the direction each time we start from power-0
+      disc_direction_positive = !disc_direction_positive;
+    }
+
+    // Adjust the power to account for disc direction
+    if (!disc_direction_positive) {
+      power = -power;
+    }
+  }
 
 	if (m_power == power) return;
 	m_power = power;

--- a/code/Raindancer/MC33926.h
+++ b/code/Raindancer/MC33926.h
@@ -54,7 +54,7 @@ public:
 
 private:
 	int m_power;
-
+  bool disc_direction_positive;
 };
 #endif
 

--- a/code/Raindancer/config.h
+++ b/code/Raindancer/config.h
@@ -127,6 +127,7 @@ Disclaimer: this code is "AS IS" and for educational purpose only.
 
 #define CONF_DISABLE_MOTOR_STALL_CHECK  false   // Disables the motor stall/encoder check in closed loop control
 #define CONF_DISABLE_MOW_MOTOR          false   // Disables the mow motor
+#define CONF_DISABLE_MOW_MOTOR_ALTERNATE_DIRECTION false // Disables the alternating of mow-motor direction
 
 #define CONF_ACTVATE_AUTO_SPIRAL        true
 
@@ -334,6 +335,7 @@ const char UBLOX_INIT[] PROGMEM =
 
 #define CONF_DISABLE_MOTOR_STALL_CHECK  false   // Disables the motor stall/encoder check in closed loop control
 #define CONF_DISABLE_MOW_MOTOR          false   // Disables the mow motor
+#define CONF_DISABLE_MOW_MOTOR_ALTERNATE_DIRECTION false // Disables the alternating of mow-motor direction
 
 #define CONF_ACTVATE_AUTO_SPIRAL        true
 
@@ -528,6 +530,7 @@ const char UBLOX_INIT[] PROGMEM =
 
 #define CONF_DISABLE_MOTOR_STALL_CHECK  true   // Disables the motor stall/encoder check in closed loop control
 #define CONF_DISABLE_MOW_MOTOR          true   // Disables the mow motor
+#define CONF_DISABLE_MOW_MOTOR_ALTERNATE_DIRECTION false // Disables the alternating of mow-motor direction
 
 #define CONF_ACTVATE_AUTO_SPIRAL        true
 


### PR DESCRIPTION
Each time the mower motor starts, alternate between
clockwise, and counter-clockwise.

This will use both sides of the cutting blades evenly.